### PR TITLE
Remove newline shmalloc_hints, prevents compilation

### DIFF
--- a/content/shmem_malloc_hints.tex
+++ b/content/shmem_malloc_hints.tex
@@ -57,19 +57,15 @@ void *@\FuncDecl{shmem\_malloc\_with\_hints}@(size_t size, long hints);
     \tabularnewline \hline
     \endhead
     %%
-    \newline
     \CONST{0} &
-    \newline
     Behavior same as \FUNC{shmem\_malloc}
     \tabularnewline \hline
 
     \LibConstDecl{SHMEM\_MALLOC\_ATOMICS\_REMOTE} &
-    \newline 
     Memory used for \VAR{atomic} operations
     \tabularnewline \hline
 
     \LibConstDecl{SHMEM\_MALLOC\_SIGNAL\_REMOTE} &
-    \newline
     Memory used for \VAR{signal} operations
     \tabularnewline \hline
 


### PR DESCRIPTION
This is a "bug" that prevents compilation of spec for myself. It can be removed and the document remains unaffected. I assume no one else has a problem with this.