### PR TITLE
[Appendix D 1.4] Add shmem_my_pe as a standard way to get process ID

### DIFF
--- a/content/interoperability.tex
+++ b/content/interoperability.tex
@@ -119,7 +119,7 @@ and the \ac{MPI} rank in \VAR{MPI\_COMM\_WORLD} of a process can be equal.
 This feature, however, may be provided by only some of the \openshmem and \ac{MPI}
 implementations (e.g., if both environments share the same underlying process
 manager) and is not portably guaranteed. A portable program should always
-use the standard functions in each model, namely, \FUNC{shmem\_team\_my\_pe} in \openshmem
+use the standard functions in each model, namely, \FUNC{shmem\_team\_my\_pe} or \FUNC{shmem\_my\_pe} in \openshmem 
 and \FUNC{MPI\_Comm\_rank} in \ac{MPI}, to query the process identification numbers
 in each communication environment and manage the mapping of identifiers in the
 program when necessary.


### PR DESCRIPTION
For OpenSHMEM the standard function is `shmem_team_my_pe()`. While this function called with `SHMEM_TEAM_WORLD` (`shmem_team_my_pe(SHMEM_TEAM_WORLD)`) is the same as calling `shmem_my_pe()`, I believe the text should include both `shmem_team_my_pe()` and `shmem_my_pe()` as "standard" ways to provide ids for OpenSHMEM PEs. `shmem_my_pe` is used later in Example 54and across the document.