### PR TITLE
backmatter: add changelog for no team wrap-arounds

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -677,6 +677,11 @@ The following list describes the specific changes in \openshmem[1.6]:
   \FUNC{shmem\_team\_ptr}.
 \ChangelogRef{subsec:shmem_team_ptr}%
 %
+\item Clarified that the behavior of \FUNC{shmem\_team\_split\_strided} is
+    undefined when the input \VAR{start}, \VAR{stride}, and \VAR{size} arguments
+    imply a \textit{wrap-around} with respect to the parent team's \acp{PE}.
+\ChangelogRef{subsec:shmem_team_split_strided}%
+%
 \item Added the session routines, \FUNC{shmem\_ctx\_session\_start} and
     \FUNC{shmem\_ctx\_session\_stop}, which allow users to pass hints to the
     \openshmem library to apply runtime optimizations.


### PR DESCRIPTION
# Summary of changes
This changelog entry might be needed if https://github.com/wokuno/specification/pull/2/files is approved and merged.

My thinking is it's not technically an errata - it came about because we clarified the behavior of negative strides, which means we had to clarify the definition of the `start` argument, but I'd say that definition was doing some heavy lifting for implying "no wrap-around".  So I believe this is simply a semantic clarification as a part of v1.6, but I could be convinced otherwise ;)

# Proposal Checklist
- [ ] Link to issue(s)
- [X] Changelog entry
- [X] Reviewed for changes to front matter
- [X] Reviewed for changes to back matter
