### PR TITLE
changelog: entry for src buffer reqs in collectives

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -708,6 +708,10 @@ The following list describes the specific changes in \openshmem[1.6]:
     stride argument is 0 or negative.
 \ChangelogRef{subsec:shmem_team_split_strided}
 %
+\item Clarified the requirements for the source buffer before entering the
+    collective routines.
+\ChangelogRef{subsec:shmem_alltoall,subsec:shmem_broadcast,subsec:shmem_collect,subsec:shmem_reductions,subsec:shmem_scan}
+%
 \item Added a new Errata Section~\ref{sec:errata} that indicates errors or ambiguities in the
     \openshmem specification and the version that required correction or clarification.
 \ChangelogRef{sec:errata}


### PR DESCRIPTION
# Summary of changes
If the clarification on source buffer requirements before entering collectives is merged:
https://github.com/davidozog/openshmem-specification/pull/10

this is the corresponding changelog entry.

# Proposal Checklist
- [x] Link to issue(s)
- [x] Changelog entry
- [x] Reviewed for changes to front matter
- [x] Reviewed for changes to back matter
